### PR TITLE
docs: add CI caching and path filter guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ All agents must follow these rules:
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
-8) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
+8) Maximize the use of caching in GitHub workflow files to minimize run duration.
+9) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary
- Replace the remote-branch fetch/pull rule with GitHub Actions caching guidance and paths/paths-ignore requirements.

## Rationale
- Align contributor instructions with CI efficiency and scope control.

## Details
- Update `AGENTS.md` only.
